### PR TITLE
fix(ISS-16): added getter for the only one loading instance node

### DIFF
--- a/src/handlers/BaseHandler.ts
+++ b/src/handlers/BaseHandler.ts
@@ -16,12 +16,12 @@ class BaseHandler {
   options: Options;
   range: Range | null;
   handler: string;
-  loading: HTMLElement;
   fileHolder: HTMLInputElement;
   handlerId: string;
   helpers = new Helpers();
   allowedFormatRegex: RegExp;
   possibleExtension: Set<string>;
+  _loading: HTMLElement;
 
   constructor(quill, options: Options) {
     this.quill = quill;
@@ -29,13 +29,6 @@ class BaseHandler {
     this.range = null;
 
     new Styled().apply();
-
-    if (this.isNotExistLoading()) {
-      const node = document.createElement('div');
-      node.innerHTML = this.helpers.loadingHTML();
-
-      this.quill.container.appendChild(node);
-    }
 
     if (typeof this.options.upload !== 'function') {
       console.warn('[Missing config] upload function that returns a promise is required');
@@ -63,11 +56,19 @@ class BaseHandler {
     }, 1);
   }
 
+  get loading(): HTMLElement {
+    if (!this._loading) {
+      const node = document.createElement('div');
+      node.innerHTML = this.helpers.loadingHTML();
+      this.quill.container.appendChild(node);
+      this._loading = node
+    }
+
+    return this._loading
+  }
+
   applyForToolbar() {
     const toolbar = this.quill.getModule('toolbar');
-    this.loading = document.getElementById(
-      `${Constants.ID_SPLIT_FLAG}.QUILL-LOADING`
-    );
     toolbar.addHandler(this.handler, this.selectLocalFile.bind(this));
   }
 
@@ -174,14 +175,6 @@ class BaseHandler {
 
   hasValidMimeType(type: string) {
     return type && type.startsWith(this.handler);
-  }
-
-  isNotExistLoading() {
-    const loading = document.getElementById(
-      `${Constants.ID_SPLIT_FLAG}.QUILL-LOADING`
-    );
-
-    return loading == null;
   }
 }
 


### PR DESCRIPTION
[ISSUE-16](https://github.com/ayush013/ngx-quill-upload/issues/16)
===
I got the following problem with the loading node:

1. Create a component which projects child content and conditionally hides it with a structure directive like `*ngIf`
2. Project `<quill-editor [modules]="modules"></quill-editor>` with connected `ImageHandler` module
3. If the component initially hides the projected content, it seems like `ImageHandler` is still getting constructed and therefore calls the creation of loading node method because of constructors maybe, which run as the first thing in Angular.
4. After creating the node, projected content gets hidden and a node gets destroyed from the DOM
5. After trying to upload an image we get the following error:
`Cannot read properties of null (reading 'removeAttribute') at ImageHandler.loadFile`

This pull request just makes sure the node will be created if there is none and returns an existing instance. 
With this code there is no error mentioned earlier